### PR TITLE
function helpers.dict_to_etree now returns etree element(as promised)…

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,5 +3,6 @@ List of people who made this library happen (alphabetic order):
 Marcin Raczyński
 Marek Bleschke
 Marek Pilarczyk
+Miłosz Zajonz
 Radosław Szalski - main contributor and project maintainer
 Łukasz Świerszcz - idea and initial work

--- a/mappet/helpers.py
+++ b/mappet/helpers.py
@@ -199,7 +199,7 @@ def dict_to_etree(d, root):
     u"""Converts a dict to lxml.etree object.
 
     >>> dict_to_etree({'root': {'#text': 'node_text', '@attr': 'val'}}, etree.Element('root'))
-    '<root><root attr="val">node_text</root></root>'
+    <Element root at 0xb8280ec>
 
     :param dict d: dict representing the XML tree
     :param etree.Element root: XML node which will be assigned the resulting tree
@@ -254,4 +254,4 @@ def dict_to_etree(d, root):
             raise AttributeError('Argument is neither dict nor basestring.')
 
     _to_etree(d, root)
-    return etree.tostring(root)
+    return root

--- a/mappet/helpers.py
+++ b/mappet/helpers.py
@@ -198,8 +198,8 @@ def etree_to_dict(t):
 def dict_to_etree(d, root):
     u"""Converts a dict to lxml.etree object.
 
-    >>> dict_to_etree({'root': {'#text': 'node_text', '@attr': 'val'}}, etree.Element('root'))
-    <Element root at 0xb8280ec>
+    >>> dict_to_etree({'root': {'#text': 'node_text', '@attr': 'val'}}, etree.Element('root')) # doctest: +ELLIPSIS
+    <Element root at 0x...>
 
     :param dict d: dict representing the XML tree
     :param etree.Element root: XML node which will be assigned the resulting tree

--- a/mappet/mappet.py
+++ b/mappet/mappet.py
@@ -256,8 +256,7 @@ class Mappet(Node):
         elif isinstance(xml, basestring):
             self._xml = etree.fromstring(xml)
         elif isinstance(xml, dict):
-            xml_str = helpers.dict_to_etree(xml, etree.Element('root'))
-            self._xml = etree.fromstring(xml_str)
+            self._xml = helpers.dict_to_etree(xml, etree.Element('root'))
         else:
             raise AttributeError('Specified data cannot be used to construct a Mappet object.')
 

--- a/mappet/tests/test_helpers.py
+++ b/mappet/tests/test_helpers.py
@@ -325,7 +325,9 @@ class TestTreeHelpers(object):
                 None,
             ]
         }
-        assert helpers.dict_to_etree(xml_dict, self.root) == '<root><node1/><node1/></root>'
+        etree_from_dict = helpers.dict_to_etree(xml_dict, self.root)
+        assert etree.iselement(etree_from_dict)
+        assert etree.tostring(etree_from_dict) == '<root><node1/><node1/></root>'
 
     def test_dict_to_etree_lists_with_mixed_children(self):
         u"""Tests the conversion of dicts with different children to an lxml tree."""
@@ -338,6 +340,6 @@ class TestTreeHelpers(object):
                 }
             ]
         }
-        assert helpers.dict_to_etree(xml_dict, self.root) == '<root><node1/><node1/><node1>text_node</node1></root>'
-
-
+        etree_from_dict = helpers.dict_to_etree(xml_dict, self.root)
+        assert etree.iselement(etree_from_dict)
+        assert etree.tostring(etree_from_dict) == '<root><node1/><node1/><node1>text_node</node1></root>'


### PR DESCRIPTION
… instead of str